### PR TITLE
Fix author name typo

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -74,7 +74,7 @@
 		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/Little_Lord_Fauntleroy</meta>
 		<meta property="se:url.vcs.github">https://github.com/standardebooks/frances-hodgson-burnett_little-lord-fauntleroy</meta>
 		<dc:creator id="author">Frances Hodgson Burnett</dc:creator>
-		<meta property="file-as" refines="#author">Burnett, Francis Hodgson</meta>
+		<meta property="file-as" refines="#author">Burnett, Frances Hodgson</meta>
 		<meta property="se:url.encyclopedia.wikipedia" refines="#author">https://en.wikipedia.org/wiki/Frances_Hodgson_Burnett</meta>
 		<meta property="se:url.authority.nacoaf" refines="#author">http://id.loc.gov/authorities/names/n80009729</meta>
 		<meta property="role" refines="#author" scheme="marc:relators">aut</meta>


### PR DESCRIPTION
Maybe something like this could be automated? I haven't looked into SE tools code (and am not even sure where to start) but author name in reverse should be easy to code up and would prevent these mistakes.